### PR TITLE
Default skill and intent handling

### DIFF
--- a/electron/app/js/intent-engines/dialogflow-intents.js
+++ b/electron/app/js/intent-engines/dialogflow-intents.js
@@ -3,6 +3,9 @@ const weather = require('js/skills/weather')
 const Timer = require('js/skills/timer')
 const event = require('js/events/events')
 const responses = require('js/responses/responses')
+const skill = require('js/skills/skill')
+const fs = require('fs')
+const path = require('path')
 
 function parseIntent(cmd){
 
@@ -39,7 +42,53 @@ function parseIntent(cmd){
 			actions.setAnswer(responses.bye, {type: 'local'})
 			break
 		default:
-			actions.setAnswer(responses.confused, {type:'local'})
+			/** Check if a skill with the name of this intent exists in js/skills **/
+                        let skillPath = path.join(process.cwd(),'app','js','skills', cmd.intent + '.js')
+                        if (fs.existsSync(skillPath)) {
+                                /** Include skill **/
+                                let skill = require('js/skills/'+cmd.intent)
+
+                                /** Check if skill is inherited from Skill class **/
+                                if (Object.getPrototypeOf(skill.constructor).name == "Skill") {
+                                        console.log(`Running skill ${cmd.intent} from js/skills/${cmd.intent}.js`)
+
+                                        /** Initialize skill **/
+                                        skill.init()
+
+                                        /** Set responseText from dialogflow **/
+                                        if (cmd.responseText) {
+                                                skill.setResponseText(cmd.responseText)
+                                        }
+
+                                        /** Set dialogflow parameters **/
+                                        for (var paramName in cmd.params) {
+                                                if (cmd.params[paramName].stringValue) {
+                                                        skill.setParam(paramName, cmd.params[paramName].stringValue)
+                                                }
+                                        }
+
+                                        /** Run skill and stop **/
+                                        skill.run()
+                                        break
+
+                                /** If skill is not inherited from Skill class, log error and go on **/
+                                } else {
+                                        console.log(`${cmd.intent} is not of type Skill (${Object.getPrototypeOf(skill.constructor).name})`)
+                                }
+                        }
+
+                        let responseTerms = []
+                        let responseLed = {anim:'blink', color: 'green'}
+
+                        /** If no skill for this intent exists, check if dialogflow gave us a responseText, 
+			    otherwise use the name of the intent **/
+                        if (cmd.responseText) {
+                                responseTerms = [cmd.responseText]
+                        } else {
+                                responseTerms = [cmd.intent]
+                                responseLed.color = 'orange'
+                        }
+                        actions.setAnswer({queryTerms: responseTerms, led: responseLed}, {type:'remote'})
 			break
 	}
 

--- a/electron/app/js/skills/datetime.js
+++ b/electron/app/js/skills/datetime.js
@@ -1,0 +1,29 @@
+const event = require('js/events/events')
+const actions = require('js/actions/actions')
+const responses = require('js/responses/responses')
+const config = require('config/config')
+const dateFormat = require('dateformat')
+const Skill = require('js/skills/skill')
+
+/**
+Displays the current time, day of the week and date with an appropriate GIF
+In Dialogflow: Create an intent namend datetime and add training phrases asking for the time and/or date
+*/
+class Datetime extends Skill{
+
+	/** Run skill **/
+	run () {
+		super.run()
+
+	        let now = new Date()
+	        let dayStr = dateFormat(now, "dddd")
+	        let dateStr = dateFormat(now, "d. mmmm yyyy")
+	        let timeStr = dateFormat(now, "HH:MM")
+	        let dateTimeStr = `${timeStr}<br /><small>${dayStr}</small><br /><small>${dateStr}</small>`
+        	actions.setAnswer({type:'remote', queryTerms: ["clock", "time", dayStr], text: dateTimeStr})
+	}
+
+}
+
+
+module.exports = new Datetime()

--- a/electron/app/js/skills/skill.js
+++ b/electron/app/js/skills/skill.js
@@ -1,0 +1,60 @@
+const event = require('js/events/events')
+
+/**
+Each skill class has to have the following functions:
+init()				Initializes the skill and allows to run basic setup
+setParam(name, value)		Allows to store parameters returned from the intent engine
+setResponseText(value)		Allows to store responseText retured from the intent engine
+setRaw(intentResponse)		Allows to store the raw intent response
+run()				Runs the skill
+**/
+class Skill {
+
+	/**
+	Initialize the class variables
+	*/
+	constructor () {
+		this.params = {}
+                this.responseText = ""
+                this.intentResponse = null
+	}
+
+	/**
+	Initialize Module and copy date format locales
+	**/
+	init () {
+		event.emit('init-skill', this.constructor.name)
+	}
+
+	/**
+	Set Parameters
+	**/
+	setParam(name, value) {
+		this.params[name] = value
+	}
+
+	/**
+	Set Response Text
+	**/
+	setResponseText (value) {
+		this.responseText = value
+	}
+
+	/**
+	Set Raw intent engine response
+	**/
+	setRaw(intentResponse) {
+		this.intentResponse = intentResponse
+	}
+
+	/**
+	Run skill
+	**/
+	run () {
+		event.emit('run-skill', this.constructor.name)
+	}
+
+}
+
+
+module.exports = Skill


### PR DESCRIPTION
I have tweaked the default handling of intents a bit:

As a smaller change, Peeqo looks up the responseText from Dialogflow (or the response from any other intent engine) or the intent name on Giphy if no intent has been defined in dialogflow-intents.js. While playing with Peeqo this has been one of the most important changes I've made so far because it allows me to add many new intents on Dialogflow without having to touch Peeqo's code.

I also propose a new skill structure which allows to add new intents in a more modular way without having to change dialogflow-intents.js. This makes it easier to fetch future updates from the Git rep without having to re-write existing skills/intents. It should also allow people to add new intents or skills which are compatible with future intent engines. Furthermore, it would be easier to download standalone skills or intents and simply copy them into one directory without having to touch any other code. 

As a demo I have added a new datetime skill which displays the current date and time.